### PR TITLE
Add requirement

### DIFF
--- a/comparer.go
+++ b/comparer.go
@@ -1,19 +1,28 @@
 package version
 
-import "golang.org/x/xerrors"
+import (
+	multierror "github.com/hashicorp/go-multierror"
+	"golang.org/x/xerrors"
+)
 
 type Comparer interface {
 	Check(v Version) bool
 }
 
 func NewComparer(v string) (Comparer, error) {
+	var errs error
+
 	c, err := NewConstraints(v)
 	if err == nil {
 		return c, nil
 	}
+	errs = multierror.Append(errs, err)
+
 	r, err := NewRequirements(v)
 	if err == nil {
 		return r, nil
 	}
-	return nil, xerrors.Errorf("failed to new comparer: %w", err)
+	errs = multierror.Append(errs, err)
+
+	return nil, xerrors.Errorf("failed to new comparer: %w", errs)
 }

--- a/comparer.go
+++ b/comparer.go
@@ -1,0 +1,19 @@
+package version
+
+import "golang.org/x/xerrors"
+
+type Comparer interface {
+	Check(v Version) bool
+}
+
+func NewComparer(v string) (Comparer, error) {
+	c, err := NewConstraints(v)
+	if err == nil {
+		return c, nil
+	}
+	r, err := NewRequirements(v)
+	if err == nil {
+		return r, nil
+	}
+	return nil, xerrors.Errorf("failed to new comparer: %w", err)
+}

--- a/comparer_test.go
+++ b/comparer_test.go
@@ -1,0 +1,89 @@
+package version
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func NewComparerTest(t *testing.T) {
+	tests := []struct {
+		s       string
+		wantErr bool
+	}{
+		// if soft requirement for 1.0. Use constraints compare
+		{"(,1.0)", false},
+		{"(,1.0]", false},
+		{"[1.0,)", false},
+		{"[1.0,]", false},
+		{"(0.9,1.0)", false},
+		{"(0.9,1.0]", false},
+		{"[1.0,1.1)", false},
+		{"[1.0,1.1]", false},
+		{"[2.4.0,2.4.2],[2.4.4]", false},
+		{"[2.4.0,2.4.2],[2.4.4],[2.5.5]", false},
+		{"1.0", false},
+		{"> 1.0", false},
+		{"< 1.0", false},
+		{"<= 1.0", false},
+		{">= 1.0", false},
+		{"== 1.0", false},
+
+		{"[1.0,1.1,1.2]", true},
+		{"[1.0,1.1,1.2]", true},
+		{"!= !=", true},
+		{"bar <", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.s, func(t *testing.T) {
+			_, err := NewComparer(tt.s)
+			if tt.wantErr {
+				assert.NotNil(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestComparerCheck(t *testing.T) {
+	tests := []struct {
+		requirement string
+		version     string
+		want        bool
+	}{
+		{"[,1.0.0]", "0.9", true},
+		{"1.0.0", "1", true},
+		{"(1.0,2.0]", "1.5", true},
+		{"(1.0,2.0]", "2.0", true},
+		{"[,1.0.0]", "0.9", true},
+		{"1.0.0", "1", true},
+		{"(1.0,2.0]", "1.5", true},
+		{"(1.0,2.0]", "2.0", true},
+		{"==4.1-alpha", "4.1.0-alpha", true},
+		{"!=4.1-alpha", "4.1.0", true},
+		{"<0-z", "0.0.0-alpha", true},
+		{"<= 2.1.0-a", "2.0.0", true},
+
+		{"< 1.0 || = 2.0", "2.0", true},
+		{"> 1.0 < 1.2 || >3.0, <4.0", "4.2", false},
+		{"(,1.0.5.RELEASE],[2.0.0.RELEASE,2.0.16.RELEASE),[2.1.0.RELEASE,2.1.3.RELEASE)", "1.0.0", true},
+		{"(,1.0.5.RELEASE],[2.0.0.RELEASE,2.0.16.RELEASE),[2.1.0.RELEASE,2.1.3.RELEASE)", "2.0.0", true},
+		{"(,1.0.5.RELEASE],[2.0.0.RELEASE,2.0.16.RELEASE),[2.1.0.RELEASE,2.1.3.RELEASE)", "2.1.3", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("%s %s", tt.version, tt.requirement), func(t *testing.T) {
+			r, err := NewComparer(tt.requirement)
+			require.NoError(t, err)
+
+			v, err := NewVersion(tt.version)
+			require.NoError(t, err)
+
+			assert.Equal(t, tt.want, r.Check(v))
+		})
+	}
+}

--- a/comparer_test.go
+++ b/comparer_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func NewComparerTest(t *testing.T) {
+func TestNewComparer(t *testing.T) {
 	tests := []struct {
 		s       string
 		wantErr bool
@@ -51,9 +51,9 @@ func NewComparerTest(t *testing.T) {
 
 func TestComparerCheck(t *testing.T) {
 	tests := []struct {
-		requirement string
-		version     string
-		want        bool
+		s       string
+		version string
+		want    bool
 	}{
 		{"[,1.0.0]", "0.9", true},
 		{"1.0.0", "1", true},
@@ -76,8 +76,8 @@ func TestComparerCheck(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Run(fmt.Sprintf("%s %s", tt.version, tt.requirement), func(t *testing.T) {
-			r, err := NewComparer(tt.requirement)
+		t.Run(fmt.Sprintf("%s %s", tt.version, tt.s), func(t *testing.T) {
+			r, err := NewComparer(tt.s)
 			require.NoError(t, err)
 
 			v, err := NewVersion(tt.version)

--- a/constraint.go
+++ b/constraint.go
@@ -26,7 +26,7 @@ var (
 )
 
 const (
-	regex = `([0-9A-Za-z\-~\.]+)`
+	constraintRegex = `([0-9A-Za-z\-~\.]+)`
 )
 
 func init() {
@@ -38,12 +38,12 @@ func init() {
 	constraintRegexp = regexp.MustCompile(fmt.Sprintf(
 		`(%s)\s*(%s)`,
 		strings.Join(ops, "|"),
-		regex))
+		constraintRegex))
 
 	validConstraintRegexp = regexp.MustCompile(fmt.Sprintf(
 		`^\s*(\s*(%s)\s*(%s)\s*\,?)*\s*$`,
 		strings.Join(ops, "|"),
-		regex))
+		constraintRegex))
 }
 
 type operatorFunc func(v, c Version) bool

--- a/constraint.go
+++ b/constraint.go
@@ -105,14 +105,14 @@ func newConstraint(c string) (constraint, error) {
 
 func (cs Constraints) Check(v Version) bool {
 	for _, c := range cs.constraints {
-		if andCheck(v, c) {
+		if andConstraintsCheck(v, c) {
 			return true
 		}
 	}
 	return false
 }
 
-func andCheck(v Version, constraints []constraint) bool {
+func andConstraintsCheck(v Version, constraints []constraint) bool {
 	for _, c := range constraints {
 		if !c.check(v) {
 			return false

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/masahiro331/go-mvn-version
 go 1.15
 
 require (
+	github.com/hashicorp/go-multierror v1.1.1
 	github.com/stretchr/testify v1.7.0
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1
 )

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,9 @@
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=
+github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
+github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+lD48awMYo=
+github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/requirement.go
+++ b/requirement.go
@@ -1,0 +1,47 @@
+package version
+
+var (
+	requirementOperation = map[string]operatorFunc{}
+)
+
+const ()
+
+func init() {
+
+}
+
+type Requirements struct {
+	requirements [][]requirement
+}
+
+type requirement struct {
+	version  Version
+	operator operatorFunc
+	original string
+}
+
+func NewRequirements(v string) (Requirements, error) {
+	return Requirements{}, nil
+}
+
+func (rs Requirements) Check(v Version) bool {
+	for _, r := range rs.requirements {
+		if andRequirementCheck(v, r) {
+			return true
+		}
+	}
+	return false
+}
+
+func andRequirementCheck(v Version, requirements []requirement) bool {
+	for _, c := range requirements {
+		if !c.check(v) {
+			return false
+		}
+	}
+	return true
+}
+
+func (r requirement) check(v Version) bool {
+	return r.operator(v, r.version)
+}

--- a/requirement.go
+++ b/requirement.go
@@ -41,7 +41,7 @@ type requirement struct {
 
 // NewRequirements is return Requirement
 // [1.0.0], [1.0.1]	=> []requirement{"[1.0.0]","[1.0.1]"}
-// [1.0.0]			=> []requirement{"[1.0.0]"}
+// [1.0.0]		=> []requirement{"[1.0.0]"}
 func NewRequirements(v string) (Requirements, error) {
 	// trimSpace "[ , 1.0.0]" => "[,1.0.0]"
 	v = trimSpaces(v)
@@ -58,10 +58,10 @@ func NewRequirements(v string) (Requirements, error) {
 	}
 
 	// Normalization
-	// "(,1.0.0)"				=> "(MIN, 1.0.0)"
-	// "(1.0.0,)"				=> "[1.0.0, MAX)"
-	// "[1.0.0]"				=> "[1.0.0, 1.0.0]"
-	// "(1.0.0]"				=> "[1.0.0, 1.0.0]"
+	// "(,1.0.0)"			=> "(MIN, 1.0.0)"
+	// "(1.0.0,)"			=> "[1.0.0, MAX)"
+	// "[1.0.0]"			=> "[1.0.0, 1.0.0]"
+	// "(1.0.0]"			=> "[1.0.0, 1.0.0]"
 	// "[,1.0.0],[1.0.0,1.1]"	=> "[,1.0.0]", "[1.0.0,1.1]"
 	requirements := requirementRegexp.FindAllString(v, -1)
 	if len(requirements) == 0 {

--- a/requirement.go
+++ b/requirement.go
@@ -10,7 +10,7 @@ import (
 var requirementRegexp *regexp.Regexp
 
 const (
-	MINVersion       = "-1"
+	MINVersion       = "-----1"
 	MAXVersion       = "99999999999999999999"
 	requirementRegex = `(` +
 		`[\[\(]` +
@@ -67,10 +67,12 @@ func NewRequirements(v string) (Requirements, error) {
 			continue
 		}
 
+		// "[,1.0.0]" => []string{"[MIN", "1.0.0]"}
 		if len(ss[0]) == 1 {
 			ss[0] = ss[0] + MINVersion
 		}
 
+		// "[,1.0.0]" => []string{"[1.0.0", "MAX]"}
 		if len(ss[1]) == 1 {
 			ss[1] = MAXVersion + ss[1]
 		}
@@ -84,6 +86,7 @@ func NewRequirements(v string) (Requirements, error) {
 		}
 		rss = append(rss, rs)
 	}
+
 	return Requirements{
 		requirements: rss,
 	}, nil
@@ -148,6 +151,10 @@ func trimSpaces(s string) string {
 	return strings.Join(strings.Fields(s), "")
 }
 
+// checkEqualOperator check equal operation.
+// e.g.
+// "[1.0.0]" => "== 1.0.0"
+// "(1.0.0)" => "== 1.0.0"
 func checkEqualOperator(r string) bool {
 	if (strings.HasPrefix(r, "[") || strings.HasPrefix(r, "(")) &&
 		(strings.HasSuffix(r, "]") || strings.HasSuffix(r, ")")) {

--- a/requirement_test.go
+++ b/requirement_test.go
@@ -14,7 +14,7 @@ func TestNewRequirements(t *testing.T) {
 		wantErr     bool
 	}{
 		// if soft requirement for 1.0. Use constraints compare
-		{"1.0", true},
+		{"1.0", false},
 
 		{"(, 1.0)", false},
 		{"(,1.0)", false},
@@ -141,6 +141,11 @@ func TestRequirementsCheck(t *testing.T) {
 		{"(,1.0.5.RELEASE],[2.0.0.RELEASE,2.0.16.RELEASE),[2.1.0.RELEASE,2.1.3.RELEASE)", "1.0.0", true},
 		{"(,1.0.5.RELEASE],[2.0.0.RELEASE,2.0.16.RELEASE),[2.1.0.RELEASE,2.1.3.RELEASE)", "2.0.0", true},
 		{"(,1.0.5.RELEASE],[2.0.0.RELEASE,2.0.16.RELEASE),[2.1.0.RELEASE,2.1.3.RELEASE)", "2.1.3", false},
+
+		// soft requirement
+		{"1.0", "2.0", true},
+		{"1.0", "1.0", true},
+		{"1.0", "0.1", true},
 	}
 
 	for _, tt := range tests {

--- a/requirement_test.go
+++ b/requirement_test.go
@@ -1,0 +1,140 @@
+package version
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewRequirements(t *testing.T) {
+	tests := []struct {
+		requirement string
+		wantErr     bool
+	}{
+		{"(, 1.0)", false},
+		{"(,1.0)", false},
+		{"(, 1.0]", false},
+		{"(,1.0]", false},
+		{"[1.0,)", false},
+		{"[1.0, )", false},
+		{"[1.0,]", false},
+		{"[1.0, ]", false},
+		{"(0.9, 1.0)", false},
+		{"(0.9, 1.0]", false},
+		{"[1.0, 1.1)", false},
+		{"[1.0, 1.1]", false},
+		{"(0.9,1.0)", false},
+		{"(0.9,1.0]", false},
+		{"[1.0,1.1)", false},
+		{"[1.0,1.1]", false},
+
+		{"[,]", false},
+		{"[0,]", false},
+		{"[,0]", false},
+		{"[0,)", false},
+		{"(,0)", false},
+		{"(0,)", false},
+		{"[0,)", false},
+		{"(,0]", false},
+
+		{"[2.4.0,2.4.2],[2.4.4]", false},
+		{"[2.4.0,2.4.2],[2.4.4],[2.5.5]", false},
+
+		{"1.0)", true},
+		{"1.0]", true},
+		{"(1.0", true},
+		{"[1.0", true},
+		{", 1.0)", true},
+		{", 1.0]", true},
+		{"(1.0, ", true},
+		{"[1.0, ", true},
+		{"<1.0", true},
+
+		{"(0.9,1.0,1.2)", true},
+		{"(0.9,1.0,1.2]", true},
+		{"[1.0,1.1,1.2)", true},
+		{"[1.0,1.1,1.2]", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.requirement, func(t *testing.T) {
+			_, err := NewRequirements(tt.requirement)
+			if tt.wantErr {
+				assert.NotNil(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestRequirementsCheck(t *testing.T) {
+	tests := []struct {
+		requirement string
+		version     string
+		want        bool
+	}{
+		{"[,1.0.0]", "0.9", true},
+		{"[,1.0.0]", "1.1", false},
+
+		{"(,1.0.0]", "0.9", true},
+		{"(,1.0.0]", "1.1", false},
+
+		{"(,1.0.0)", "0.9", true},
+		{"(,1.0.0)", "1.0.0", false},
+		{"(,1.0.0)", "1.0.1", false},
+
+		{"[,1.0.0)", "0.9", true},
+		{"[,1.0.0)", "1.0.0", false},
+		{"[,1.0.0)", "1.0.1", false},
+
+		{"[0,)", "0.9", true},
+		{"[0,)", "1.0.0", true},
+		{"[0,)", "1.0.1", true},
+
+		{"(,0)", "0.9", true},
+		{"(,0)", "1.0.0", true},
+		{"(,0)", "1.0.1", true},
+
+		{"[,]", "0.9", true},
+		{"[,]", "1.0.0", true},
+		{"[,]", "1.0.1", true},
+
+		{"[1.0.0,)", "1.0.0", true},
+		{"[1.0.0,)", "1.0.1", true},
+		{"[1.0.0,)", "0.9", false},
+
+		{"[1.0.0]", "1.0.0", true},
+		{"[1.0.0]", "1.0.1", false},
+		{"[1.0.0]", "0.9", false},
+
+		{"[1.0.0]", "1.0.0", true},
+		{"[1.0.0]", "1.0.1", false},
+		{"[1.0.0]", "0.9", false},
+
+		{"[1.0,2.0)", "1.0.0", true},
+		{"[1.0,2.0)", "1.5", true},
+		{"[1.0,2.0)", "0.9", true},
+		{"[1.0,2.0)", "2.0", false},
+
+		{"[1.0,2.0]", "1.0.0", true},
+		{"[1.0,2.0]", "1.5", true},
+		{"[1.0,2.0]", "2.0", true},
+		{"[1.0,2.0]", "0.9", false},
+		{"[1.0,2.0]", "2.1", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("%s %s", tt.version, tt.requirement), func(t *testing.T) {
+			r, err := NewRequirements(tt.requirement)
+			require.NoError(t, err)
+
+			v, err := NewVersion(tt.version)
+			require.NoError(t, err)
+
+			assert.Equal(t, tt.want, r.Check(v))
+		})
+	}
+}

--- a/requirement_test.go
+++ b/requirement_test.go
@@ -13,6 +13,9 @@ func TestNewRequirements(t *testing.T) {
 		requirement string
 		wantErr     bool
 	}{
+		// if soft requirement for 1.0. Use constraints compare
+		{"1.0", true},
+
 		{"(, 1.0)", false},
 		{"(,1.0)", false},
 		{"(, 1.0]", false},
@@ -77,9 +80,11 @@ func TestRequirementsCheck(t *testing.T) {
 		want        bool
 	}{
 		{"[,1.0.0]", "0.9", true},
+		{"[,1.0.0]", "1.0", true},
 		{"[,1.0.0]", "1.1", false},
 
 		{"(,1.0.0]", "0.9", true},
+		{"(,1.0.0]", "1.0", true},
 		{"(,1.0.0]", "1.1", false},
 
 		{"(,1.0.0)", "0.9", true},
@@ -94,9 +99,9 @@ func TestRequirementsCheck(t *testing.T) {
 		{"[0,)", "1.0.0", true},
 		{"[0,)", "1.0.1", true},
 
-		{"(,0)", "0.9", true},
-		{"(,0)", "1.0.0", true},
-		{"(,0)", "1.0.1", true},
+		{"(,0)", "0.9", false},
+		{"(,0)", "1.0.0", false},
+		{"(,0)", "1.0.1", false},
 
 		{"[,]", "0.9", true},
 		{"[,]", "1.0.0", true},
@@ -110,13 +115,14 @@ func TestRequirementsCheck(t *testing.T) {
 		{"[1.0.0]", "1.0.1", false},
 		{"[1.0.0]", "0.9", false},
 
-		{"[1.0.0]", "1.0.0", true},
-		{"[1.0.0]", "1.0.1", false},
-		{"[1.0.0]", "0.9", false},
+		// (1.0.0) is not defined requirements. use [1.0.0] compare.
+		{"(1.0.0)", "1.0.0", true},
+		{"(1.0.0)", "1.0.1", false},
+		{"(1.0.0)", "0.9", false},
 
 		{"[1.0,2.0)", "1.0.0", true},
 		{"[1.0,2.0)", "1.5", true},
-		{"[1.0,2.0)", "0.9", true},
+		{"[1.0,2.0)", "0.9", false},
 		{"[1.0,2.0)", "2.0", false},
 
 		{"[1.0,2.0]", "1.0.0", true},
@@ -124,6 +130,17 @@ func TestRequirementsCheck(t *testing.T) {
 		{"[1.0,2.0]", "2.0", true},
 		{"[1.0,2.0]", "0.9", false},
 		{"[1.0,2.0]", "2.1", false},
+
+		{"(1.0,2.0]", "1.0.0", false},
+		{"(1.0,2.0]", "1.5", true},
+		{"(1.0,2.0]", "2.0", true},
+		{"(1.0,2.0]", "0.9", false},
+		{"(1.0,2.0]", "2.1", false},
+		{"(1.0,2.0]", "2.1", false},
+
+		{"(,1.0.5.RELEASE],[2.0.0.RELEASE,2.0.16.RELEASE),[2.1.0.RELEASE,2.1.3.RELEASE)", "1.0.0", true},
+		{"(,1.0.5.RELEASE],[2.0.0.RELEASE,2.0.16.RELEASE),[2.1.0.RELEASE,2.1.3.RELEASE)", "2.0.0", true},
+		{"(,1.0.5.RELEASE],[2.0.0.RELEASE,2.0.16.RELEASE),[2.1.0.RELEASE,2.1.3.RELEASE)", "2.1.3", false},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
# Support maven requirement.
https://maven.apache.org/pom.html#dependency-version-requirement-specification

--- 
## Comparer

Requirement support `soft requirement`.    
Soft-requirement `1.0` always return true.  

Support common compare interface.   
Sample code.  
```
// constraint
c, _ := version.NewComparer("> 1.0.0")
v, _ := version.NewVersion("0.9")
c.Check(v)

// requirement
c, _ := version.NewComparer("(, 1.0.0)")
v, _ := version.NewVersion("0.9")
c.Check(v)
```

## Requirement 

Requirement implemented three flow. 

1. Normalization
  `[1.0.0]` => `[1.0.0]` // nothing  
  `(1.0.0 , 2.0.0]` => `(1.0.0,2.0.0]` // trim space  
  `[, 2.0.0)` => `[-----1,2.0.0)`  
  `(1.0.0, )` => `(1.0.0,99999999999999999999)`  
 
2. Resolve Operator 
  `[1.0.0]` => `==1.0.0`  
  `(1.0.0, 2.0.0]` => `>1.0.0 && <=2.0.0`  
  `[-----1, 2.0.0)` => `>-----1 && <2.0.0`  
  `(1.0.0, )` => `>1.0.0 && <99999999999999999999`  
  `(1.0.0, 2.0.0], [3.0.0, )`  => `>1.0.0 && <=2.0.0 || >=3.0.0 && <99999999999999999999`  
 
3. Compare
  compare... 
