### PR TITLE
upgrade and clean up dependencies

### DIFF
--- a/comparer.go
+++ b/comparer.go
@@ -1,8 +1,9 @@
 package version
 
 import (
-	multierror "github.com/hashicorp/go-multierror"
-	"golang.org/x/xerrors"
+	"fmt"
+
+	"github.com/hashicorp/go-multierror"
 )
 
 type Comparer interface {
@@ -24,5 +25,5 @@ func NewComparer(v string) (Comparer, error) {
 	}
 	errs = multierror.Append(errs, err)
 
-	return nil, xerrors.Errorf("failed to new comparer: %w", errs)
+	return nil, fmt.Errorf("failed to new comparer: %w", errs)
 }

--- a/constraint.go
+++ b/constraint.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
-
-	"golang.org/x/xerrors"
 )
 
 var (
@@ -63,7 +61,7 @@ func NewConstraints(v string) (Constraints, error) {
 	var css [][]constraint
 	for _, vv := range strings.Split(v, "||") {
 		if !validConstraintRegexp.MatchString(vv) {
-			return Constraints{}, xerrors.Errorf("improper constraint: %s", vv)
+			return Constraints{}, fmt.Errorf("improper constraint: %s", vv)
 		}
 
 		ss := constraintRegexp.FindAllString(vv, -1)
@@ -89,12 +87,12 @@ func NewConstraints(v string) (Constraints, error) {
 func newConstraint(c string) (constraint, error) {
 	m := constraintRegexp.FindStringSubmatch(c)
 	if m == nil {
-		return constraint{}, xerrors.Errorf("improper constraint: %s", c)
+		return constraint{}, fmt.Errorf("improper constraint: %s", c)
 	}
 
 	v, err := NewVersion(m[2])
 	if err != nil {
-		return constraint{}, xerrors.Errorf("version parse error (%s): %w", m[2], err)
+		return constraint{}, fmt.Errorf("version parse error (%s): %w", m[2], err)
 	}
 	return constraint{
 		version:  v,

--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,15 @@
 module github.com/masahiro331/go-mvn-version
 
-go 1.15
+go 1.19
 
 require (
 	github.com/hashicorp/go-multierror v1.1.1
-	github.com/stretchr/testify v1.7.0
-	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1
+	github.com/stretchr/testify v1.8.1
+)
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/hashicorp/errwrap v1.0.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,6 @@
-github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+lD48awMYo=
@@ -7,11 +8,14 @@ github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
-github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
-github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 h1:go1bK/D/BFZV2I8cIQd1NKEZ+0owSTG1fDTci4IqFcE=
-golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
+github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
+github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
+github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
+github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/requirement.go
+++ b/requirement.go
@@ -1,10 +1,9 @@
 package version
 
 import (
+	"fmt"
 	"regexp"
 	"strings"
-
-	"golang.org/x/xerrors"
 )
 
 var (
@@ -50,7 +49,7 @@ func NewRequirements(v string) (Requirements, error) {
 	if softRequirementRegexp.MatchString(v) {
 		r, err := newRequirement(v)
 		if err != nil {
-			return Requirements{}, xerrors.Errorf("improper soft requirements: %v", v)
+			return Requirements{}, fmt.Errorf("improper soft requirements: %v", v)
 		}
 		return Requirements{
 			requirements: append(rss, []requirement{r}),
@@ -65,19 +64,19 @@ func NewRequirements(v string) (Requirements, error) {
 	// "[,1.0.0],[1.0.0,1.1]"	=> "[,1.0.0]", "[1.0.0,1.1]"
 	requirements := requirementRegexp.FindAllString(v, -1)
 	if len(requirements) == 0 {
-		return Requirements{}, xerrors.Errorf("improper requirements: %v", requirements)
+		return Requirements{}, fmt.Errorf("improper requirements: %v", requirements)
 	}
 
 	for _, r := range requirements {
 		var rs []requirement
 		ss := strings.Split(r, ",")
 		if len(ss) > 2 {
-			return Requirements{}, xerrors.Errorf("improper requirement length: %v", r)
+			return Requirements{}, fmt.Errorf("improper requirement length: %v", r)
 		}
 		if len(ss) == 1 && checkEqualOperator(ss[0]) {
 			nr, err := newRequirement(ss[0])
 			if err != nil {
-				return Requirements{}, xerrors.Errorf("failed to parse requirement: %w", err)
+				return Requirements{}, fmt.Errorf("failed to parse requirement: %w", err)
 			}
 			rss = append(rss, append(rs, nr))
 			continue
@@ -96,7 +95,7 @@ func NewRequirements(v string) (Requirements, error) {
 		for _, single := range ss {
 			nr, err := newRequirement(single)
 			if err != nil {
-				return Requirements{}, xerrors.Errorf("failed to parse requirement: %w", err)
+				return Requirements{}, fmt.Errorf("failed to parse requirement: %w", err)
 			}
 			rs = append(rs, nr)
 		}
@@ -133,7 +132,7 @@ func newRequirement(r string) (requirement, error) {
 		operator = requirementSoftRequirement
 	}
 	if err != nil {
-		return requirement{}, xerrors.Errorf("failed to new version: %w", err)
+		return requirement{}, fmt.Errorf("failed to new version: %w", err)
 	}
 	return requirement{
 		version:  v,

--- a/version_test.go
+++ b/version_test.go
@@ -3,7 +3,7 @@ package version_test
 import (
 	"testing"
 
-	version "github.com/masahiro331/go-mvn-version"
+	"github.com/masahiro331/go-mvn-version"
 )
 
 func TestEqual(t *testing.T) {


### PR DESCRIPTION
This PR upgrades, and cleans up dependencies.

Upgrades include:
- Testify to 1.8.1 (latest)
- `go` directive to 1.19

More specifically, the cleanup consisted of:
- [xerrors](https://pkg.go.dev/golang.org/x/xerrors) package is replaced with `fmt`, since it is only used for `Errorf`.
- Trivial package aliases were removed. Example: No need to have `multierror` as an alias for `go-multierror`.

Tests all pass as expected:
```
❯ go test
PASS
ok  	github.com/masahiro331/go-mvn-version	0.293s
```