### PR TITLE
feat: support version which contains underscore

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -3,16 +3,13 @@ name: Test
 jobs:
   test:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        go-version: [1.21.x]
     steps:
-      - name: Install Go
-        uses: actions/setup-go@v2
-        with:
-          go-version: ${{ matrix.go-version }}
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4.2.2
+      - name: Install Go
+        uses: actions/setup-go@v5.3.0
+        with:
+          go-version-file: "go.mod"
       - name: Lint
         uses: golangci/golangci-lint-action@v6.2.0
       - name: Run unit tests

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [1.14.x, 1.15.x]
+        go-version: [1.21.x]
     steps:
       - name: Install Go
         uses: actions/setup-go@v2
@@ -16,7 +16,7 @@ jobs:
       - name: Lint
         uses: golangci/golangci-lint-action@v2
         with:
-          version: v1.31
+          version: v6.2.0
           args: --deadline=30m
       - name: Run unit tests
         run: go test ./...

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -14,9 +14,6 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
       - name: Lint
-        uses: golangci/golangci-lint-action@v2
-        with:
-          version: v6.2.0
-          args: --deadline=30m
+        uses: golangci/golangci-lint-action@v6.2.0
       - name: Run unit tests
         run: go test ./...

--- a/constraint.go
+++ b/constraint.go
@@ -26,7 +26,7 @@ var (
 )
 
 const (
-	constraintRegex = `([0-9A-Za-z\-~\.]+)`
+	constraintRegex = `([0-9A-Za-z\-~_\.]+)`
 )
 
 func init() {

--- a/constraint_test.go
+++ b/constraint_test.go
@@ -100,6 +100,8 @@ func TestVersion_Check(t *testing.T) {
 		{"<1.1", "0.1.0", true},
 		{"<1.1", "1.1.0", false},
 		{"<1.1", "1.1.1", false},
+		{"<1_1", "1", true},                                         // https://github.com/masahiro331/go-mvn-version/pull/11
+		{"<1087.1089.v2f1b_9a_b_040e4", "1087.v16065d268466", true}, // https://github.com/masahiro331/go-mvn-version/pull/11
 
 		// Less than or equal
 		{"<=0.2.3", "1.2.3", false},

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/masahiro331/go-mvn-version
 
-go 1.21.3
+go 1.23
 
 require (
 	github.com/hashicorp/go-multierror v1.1.1

--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,16 @@
 module github.com/masahiro331/go-mvn-version
 
-go 1.15
+go 1.21.3
 
 require (
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/stretchr/testify v1.7.0
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1
+)
+
+require (
+	github.com/davecgh/go-spew v1.1.0 // indirect
+	github.com/hashicorp/errwrap v1.0.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
 )


### PR DESCRIPTION
eg.
>=1087.v16065d268466, <1087.1089.v2f1b_9a_b_040e4

for org.jenkins-ci.plugins:credentials maven package

@knqyf263 please review.