### PR TITLE
feat: support '+' in constraint version

### DIFF
--- a/constraint.go
+++ b/constraint.go
@@ -26,7 +26,7 @@ var (
 )
 
 const (
-	constraintRegex = `([0-9A-Za-z\-~_\.]+)`
+	constraintRegex = `([0-9A-Za-z\-~_\.\+]+)`
 )
 
 func init() {

--- a/constraint_test.go
+++ b/constraint_test.go
@@ -22,6 +22,7 @@ func TestNewConstraints(t *testing.T) {
 		{">40.50.60, < 50.70", false},
 		{"2.0", false},
 		{"2.3.5-20161202202307-sha.e8fc5e5", false},
+		{"2.3.5+build.1", false},
 		{">= bar", false},
 		{">= 1.1.1.v1", false},
 		{">= 1.1.1.1v", false},
@@ -100,8 +101,10 @@ func TestVersion_Check(t *testing.T) {
 		{"<1.1", "0.1.0", true},
 		{"<1.1", "1.1.0", false},
 		{"<1.1", "1.1.1", false},
-		{"<1_1", "1", true},                                         // https://github.com/masahiro331/go-mvn-version/pull/11
-		{"<1087.1089.v2f1b_9a_b_040e4", "1087.v16065d268466", true}, // https://github.com/masahiro331/go-mvn-version/pull/11
+		{"<1_1", "1", true}, // https://github.com/masahiro331/go-mvn-version/pull/11
+		{
+			"<1087.1089.v2f1b_9a_b_040e4", "1087.v16065d268466", true,
+		}, // https://github.com/masahiro331/go-mvn-version/pull/11
 
 		// Less than or equal
 		{"<=0.2.3", "1.2.3", false},

--- a/constraint_test.go
+++ b/constraint_test.go
@@ -105,6 +105,10 @@ func TestVersion_Check(t *testing.T) {
 		{
 			"<1087.1089.v2f1b_9a_b_040e4", "1087.v16065d268466", true,
 		}, // https://github.com/masahiro331/go-mvn-version/pull/11
+		{"<0.0.5+sp555", "0.1.0", false},
+		{"<0.0.5+sp555", "0.0.5", true},
+		{"<0.0.5+sp555", "0.0.5+sp1", true},
+		{"<0.0.5+sp555", "0.0.5+sp999", false},
 
 		// Less than or equal
 		{"<=0.2.3", "1.2.3", false},
@@ -141,6 +145,10 @@ func TestVersion_Check(t *testing.T) {
 		{">11.1", "11.1.0", false},
 		{">11.1", "11.1.1", true}, // different
 		{">11.1", "11.2.1", true},
+		{">0.0.5+sp555", "0.1.0", true},
+		{">0.0.5+sp555", "0.0.5", false},
+		{">0.0.5+sp555", "0.0.5+sp1", false},
+		{">0.0.5+sp555", "0.0.5+sp999", true},
 
 		// Greater than or equal
 		{">=11.1.3", "11.1.2", false},
@@ -165,6 +173,8 @@ func TestVersion_Check(t *testing.T) {
 		{">=1.1", "1.1.0", true},
 		{">=1.1", "0.0.9", false},
 		{">=0", "0.0.0", true},
+		{">=0.0.5+sp555", "0.0.5", false},
+		{">=0.0.5+sp555", "0.0.5+sp1", false},
 
 		// More than 3 numbers
 		{"< 1.0.0.1 || = 2.0.1.2.3", "2.0", false},


### PR DESCRIPTION
## Description 
The constraint parser was rejecting versions that contain + (e.g., 2.3.5+build.1), which caused a failure.
The `+` character is valid in Maven — it’s treated as a normal character in the qualifier, not as a build-metadata separator (unlike in SemVer).

## Example
```
➜  java -jar $JAR "6.0.0" "6.0.0+root.io.1"
Display parameters as parsed by Maven (in canonical form and as a list of tokens) and comparison result:
1. 6.0.0 -> 6; tokens: [6]
   6.0.0 < 6.0.0+root.io.1
2. 6.0.0+root.io.1 -> 6-+root.io.1; tokens: [6, [+root, io, 1]]
➜ java -cp $JAR RangeCheck.java "(,5.15.12+sp999)" "5.15.12"
true
➜ java -cp $JAR RangeCheck.java "(,5.15.12+sp999)" "5.15.12+sp1"
true
➜ java -cp $JAR RangeCheck.java "(,5.15.12+sp555)" "5.15.12+sp999"
false

```
